### PR TITLE
revamped the logic of getCurrentRotation function

### DIFF
--- a/add-rotate-image-button.js
+++ b/add-rotate-image-button.js
@@ -30,35 +30,20 @@ const rotateImage = () => {
 }
 
 const getCurrentRotation = (element) => {
-    const PROP = "rotate";
-    const transformString = element.style.transform;
-    let currString = "";
-    let propIndex = -1;
-    let stringValue = "";
-
-    // Find property name to get "(" index.
-    for (let i = 0; i < transformString.length; i++) {
-        if (currString.length < PROP.length) {
-            currString += transformString[i];
-        }
-        if (currString.length == PROP.length) {
-            if (currString == PROP) {
-                propIndex = i+1;
-                break;
-            }
-            currString += transformString[i];
-            currString = currString.substring(1);
-        }  
+    // Get the transform property value from the element's style
+    const transformString = element.style.transform || window.getComputedStyle(element).transform;
+    // Use a regular expression to match the rotation value in the transform property
+    const match = transformString.match(/rotate\(([-+]?\d*\.?\d+)(?:deg)?\)/);
+    // Check if a match is found and extract the rotation value
+    if (match && match[1]) {
+        // Convert the rotation value to a floating-point number
+        return parseFloat(match[1]);
+    } else {
+        // Return 0 if no rotation value is found
+        return 0;
     }
+};
 
-    if (propIndex == -1 || transformString.charAt(propIndex) != "(") return 0;    
-    let i = propIndex+1;
-    while (transformString.charAt(i) != ")") {
-        stringValue += transformString.charAt(i);
-        i++;
-    }
-    return parseInt(stringValue.substring(0, stringValue.length-3));
-}
 
 var observer = new WebKitMutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {


### PR DESCRIPTION
Subject: Pull Request: Enhancements to getCurrentRotation Function

Hi @estevE11,

I've incorporated your suggestion to use the `transformString.split('rotate(')[1].split('deg)')[0]` approach for the getCurrentRotation function. While this method offers conciseness, my analysis revealed potential vulnerabilities in its adaptability to changes in the transform property structure.

In response, I chose to implement a regular expression (regex) solution. This approach explicitly defines the expected pattern within the transform property, significantly reducing the risk of breakage in the event of structural modifications. I believe this adjustment strengthens the robustness and maintainability of the function.

For your convenience, I've attached a demonstration of the updated code. After a prolonged absence, I'm resuming my contributions to open source. Please let me know if any further improvements are needed.

Best regards,
@shadow-ryu